### PR TITLE
adds refresh date and time to feeds.php

### DIFF
--- a/inc_0700/config_inc.php
+++ b/inc_0700/config_inc.php
@@ -21,7 +21,7 @@
 # START SETTINGS (show or hide page errors, turn on/off error logging)---------------------------------------------
 # We can un-comment the line below to either see default errors (1) or shut off visual errors completely (0). 
 //ini_set('error_reporting', E_ALL | E_STRICT);  # E_ALL | E_STRICT = currently tracking all errors & warnings
-$sub_folder = 'wn19test/';//If app installed in subfolder, place here.  name of folder, no leading or trailing forward or backslash
+$sub_folder = 'wn19/';//If app installed in subfolder, place here.  name of folder, no leading or trailing forward or backslash
 define('SHOW_ALL_ERRORS', true); # TRUE = SHOW ALL SITE ERRORS - if FALSE must be logged in as ADMIN to view errors
 define('LOG_ALL_ERRORS', true); # TRUE = TRACK ALL ERRORS IN ERROR LOG FILE (UPDATED 7/14 FOR ZEPHIR!)
 define('SECURE',true); # true forces secure connection, https, for all site pages
@@ -45,8 +45,6 @@ if (SECURE && $_SERVER['SERVER_PORT'] != 443) {#redirect to force HTTPS
 }else{//add protocol to virtual path
     $protocol = SECURE ? 'https://' : 'http://';
 }
-//ini_set('session.save_path','/home/classes/horsey01/sessions'); #optional folder set to 0700 outside webroot to store session data
-//ini_set('session.cookie_domain', '.seattlecentral.edu'); # "dot" (period) then domain name - apply session cookies to subdomains, incl www!
 header("Cache-Control: no-cache");header("Expires: -1");#Helps stop browser & proxy caching
 # END SETTINGS (php.ini overrides & other enviroment settings)------------------------------------------------------------ 
 
@@ -75,7 +73,7 @@ ini_set('session.gc_maxlifetime', '3600'); //set session duration (maxlifetime) 
 //include INCLUDE_PATH . 'session_db_inc.php'; //Session database handling include file
 ini_set('session.save_path','/home/thohar69/sessions'); // Change default session storage
 $cookie_path = "/";
-$cookie_timeout = 60 * 30; // in seconds
+$cookie_timeout = 60 * 20; // in seconds
 session_set_cookie_params($cookie_timeout, $cookie_path);
 
 # CONTENT CONFIGURATION AREA (theme, content areas & nav arrays for header/footer )-----------------------------------------

--- a/news/feed.php
+++ b/news/feed.php
@@ -42,14 +42,20 @@ $resultTopicID = mysqli_query(IDB::conn(),$sqlTopicID) or die(trigger_error(mysq
 <?php
 if(mysqli_num_rows($resultTopicID) > 0){
     $file = ''; //initialize the $file variable coming back from getRssFeed()
+    $feedRefreshTime = 0;
+    $feedData = array();
     $row = mysqli_fetch_assoc($resultTopicID);
     $url = $row['TopicURL'];
     $currentTopicID = intval($row['TopicID']);
-    $file = getRssFeed($currentTopicID, $url);
+    $feedData = getRssFeed($currentTopicID, $url, $cookie_timeout);
+    $file = $feedData[0];
+    $feedRefreshTime = $feedData[1];
+    //for loop
+    for($x=0; $x<count($feedData); $x++) // $x++ means where x=x+1
     $result = new SimpleXMLElement($file);
-
     echo '<h3> <center>'. $row['TopicName'] . '</center></h3> ';
-
+    echo '<p>Last refresh of this feed was: ' . $feedRefreshTime . '</p>';
+    
     $image_url = '';
     $number = 1;
     foreach($result->channel->item as $item){

--- a/news/inc_news/config_news.php
+++ b/news/inc_news/config_news.php
@@ -112,8 +112,7 @@ class NewsFeed{
    * @todo none
    */
 
-function getRssFeed($currentTopicID, $url) {
-    $maxSession = 3 * 60;
+function getRssFeed($currentTopicID, $url, $maxSession) {
     $file = '';
     $secondsSinceRefresh = 0;
     $sessionFoundAlive = 'no';
@@ -124,6 +123,7 @@ function getRssFeed($currentTopicID, $url) {
     }else{//loop through objects in the session to find the topicID if it exists and is not expired
         foreach ($_SESSION['NewsFeeds'] as $feed) {
             if($feed->TopicID == $currentTopicID) {// find the topicID
+                $lastRefresh = date('m/d/Y H:i:s', $feed->SessionStartTime);
                 $secondsSinceRefresh =  (time() - $feed->SessionStartTime);//add 10 seconds to allow time for retrieval
                 if(($maxSession >  $secondsSinceRefresh + 2) && ($sessionFoundAlive == 'no')) {//use the session if it is fresh (2 second jic is added)
                     $sessionFoundAlive = 'yes';
@@ -137,9 +137,12 @@ function getRssFeed($currentTopicID, $url) {
     if($sessionFoundAlive == 'no'){
         $file = file_get_contents($url);// get the rss feed from the internet
         $_SESSION['NewsFeeds'][] = new NewsFeed($currentTopicID, time(), $file);
+        $lastRefresh = date('m/d/Y H:i:s', time());
         $secondsSinceRefresh = 0;
     }
-    return $file;   
+
+    $feedData = array($file, $lastRefresh);
+    return $feedData; 
 }
 
 ?>


### PR DESCRIPTION
This request:
1) updates feed.php to
-- display the date & time of the last refresh
-- use the cookie timeout as input to getRssFeed()

2) updates config_news.php function getRssFeed()
-- changed the return to an array
-- return includes the rss feed and the feed refresh date/time
-- accept a maxSession parm to set the feed maximum time

3) updates config_inc.php
-- sets the cookie timeout to 20 minutes (60 * 20)
-- cleaned up some commented out rows that were duplicate anyway

Working code here: https://kiseharrington.com/wn19/news/